### PR TITLE
Add support for multiple HTTP methods

### DIFF
--- a/docs/docs.md
+++ b/docs/docs.md
@@ -99,15 +99,16 @@ Get a URL providing the specified response.
 ### Method: MockWebServer->setResponseOfPath
 
 ```php
-function setResponseOfPath($path, $response)
+function setResponseOfPath($path, $response, $method)
 ```
 
-Set a specified path to provide a specific response
+Set a specified path to provide a specific response for a specified HTTP method.
 
 #### Parameters:
 
 - ***string*** `$path`
 - ***\donatj\MockWebServer\ResponseInterface*** `$response`
+- ***string*** `$method`
 
 #### Returns:
 

--- a/example/methods.php
+++ b/example/methods.php
@@ -1,0 +1,27 @@
+<?php
+
+use donatj\MockWebServer\MockWebServer;
+use donatj\MockWebServer\Response;
+use donatj\MockWebServer\RequestInfo;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+$server = new MockWebServer;
+$server->start();
+
+// Create a response for both a POST and GET request to the same URL:
+$urls = [];
+$urls['GET']  = $server->setResponseOfPath('/foo/bar', new Response('This is our http GET response'), RequestInfo::GET);
+$urls['POST'] = $server->setResponseOfPath('/foo/bar', new Response('This is our http POST response'), RequestInfo::POST);
+
+foreach (['GET', 'POST'] as $method)
+{
+    $url = $urls[$method];
+
+    echo "$method request to $url:\n";
+
+    $context = stream_context_create(['http' => ['method'  => $method]]);
+    $content = file_get_contents($url, false, $context);
+
+    echo $content . "\n\n";
+}

--- a/example/methods.php
+++ b/example/methods.php
@@ -10,13 +10,11 @@ $server = new MockWebServer;
 $server->start();
 
 // Create a response for both a POST and GET request to the same URL:
-$urls = [];
-$urls['GET']  = $server->setResponseOfPath('/foo/bar', new Response('This is our http GET response'), RequestInfo::GET);
-$urls['POST'] = $server->setResponseOfPath('/foo/bar', new Response('This is our http POST response'), RequestInfo::POST);
+$methods = [RequestInfo::GET, RequestInfo::POST];
 
-foreach (['GET', 'POST'] as $method)
+foreach ($methods as $method)
 {
-    $url = $urls[$method];
+    $url = $server->setResponseOfPath('/foo/bar', new Response("This is our http $method response"), $method);
 
     echo "$method request to $url:\n";
 

--- a/src/InternalServer.php
+++ b/src/InternalServer.php
@@ -79,7 +79,7 @@ class InternalServer {
 		file_put_contents($this->tmpPath . DIRECTORY_SEPARATOR . 'request.' . $count, $reqStr);
 	}
 
-	public static function aliasPath( $tmpPath, $path, $method = 'GET' ) {
+	public static function aliasPath( $tmpPath, $path, $method = RequestInfo::GET ) {
 		$path   = '/' . ltrim($path, '/');
         $method = strtoupper($method);
 
@@ -137,8 +137,6 @@ class InternalServer {
 
 		$uriPath   = $this->request->getParsedUri()['path'];
 		$aliasPath = self::aliasPath($this->tmpPath, $uriPath, $this->request->getRequestMethod());
-
-		echo $aliasPath;
 
 		if( file_exists($aliasPath) ) {
 			if( $path = file_get_contents($aliasPath) ) {

--- a/src/InternalServer.php
+++ b/src/InternalServer.php
@@ -79,10 +79,11 @@ class InternalServer {
 		file_put_contents($this->tmpPath . DIRECTORY_SEPARATOR . 'request.' . $count, $reqStr);
 	}
 
-	public static function aliasPath( $tmpPath, $path ) {
-		$path = '/' . ltrim($path, '/');
+	public static function aliasPath( $tmpPath, $path, $method = 'GET' ) {
+		$path   = '/' . ltrim($path, '/');
+        $method = strtoupper($method);
 
-		return $tmpPath . DIRECTORY_SEPARATOR . 'alias.' . md5($path);
+		return sprintf('%s%salias.%s.%s', $tmpPath, DIRECTORY_SEPARATOR, md5($path), $method);
 	}
 
 	public function __invoke() {
@@ -135,7 +136,10 @@ class InternalServer {
 		$path = false;
 
 		$uriPath   = $this->request->getParsedUri()['path'];
-		$aliasPath = self::aliasPath($this->tmpPath, $uriPath);
+		$aliasPath = self::aliasPath($this->tmpPath, $uriPath, $this->request->getRequestMethod());
+
+		echo $aliasPath;
+
 		if( file_exists($aliasPath) ) {
 			if( $path = file_get_contents($aliasPath) ) {
 				$path = $this->tmpPath . DIRECTORY_SEPARATOR . $path;

--- a/src/MockWebServer.php
+++ b/src/MockWebServer.php
@@ -162,12 +162,10 @@ class MockWebServer {
      * @param string $method HTTP method
 	 * @return string
 	 */
-	public function setResponseOfPath( $path, ResponseInterface $response, $method = 'GET' ) {
+	public function setResponseOfPath( $path, ResponseInterface $response, $method = RequestInfo::GET ) {
 		$ref = InternalServer::storeResponse($this->tmpDir, $response);
 
 		$aliasPath = InternalServer::aliasPath($this->tmpDir, $path, $method);
-
-		echo $aliasPath . PHP_EOL;
 
 		if( !file_put_contents($aliasPath, $ref) ) {
 			throw new \RuntimeException('Failed to store path alias');

--- a/src/MockWebServer.php
+++ b/src/MockWebServer.php
@@ -159,12 +159,15 @@ class MockWebServer {
 	 *
 	 * @param string                                  $path
 	 * @param \donatj\MockWebServer\ResponseInterface $response
+     * @param string $method HTTP method
 	 * @return string
 	 */
-	public function setResponseOfPath( $path, ResponseInterface $response ) {
+	public function setResponseOfPath( $path, ResponseInterface $response, $method = 'GET' ) {
 		$ref = InternalServer::storeResponse($this->tmpDir, $response);
 
-		$aliasPath = InternalServer::aliasPath($this->tmpDir, $path);
+		$aliasPath = InternalServer::aliasPath($this->tmpDir, $path, $method);
+
+		echo $aliasPath . PHP_EOL;
 
 		if( !file_put_contents($aliasPath, $ref) ) {
 			throw new \RuntimeException('Failed to store path alias');

--- a/src/RequestInfo.php
+++ b/src/RequestInfo.php
@@ -16,6 +16,16 @@ class RequestInfo implements \JsonSerializable {
 
 	const JSON_KEY_PARSED_REQUEST_URI = 'PARSED_REQUEST_URI';
 
+	const GET     = 'GET';
+	const POST    = 'POST';
+	const PUT     = 'PUT';
+	const PATCH   = 'PATCH';
+	const DELETE  = 'DELETE';
+	const HEAD    = 'HEAD';
+	const OPTIONS = 'OPTIONS';
+	const TRACE   = 'TRACE';
+	const CONNECT = 'CONNECT';
+
 	/**
 	 * @var mixed
 	 */

--- a/src/RequestInfo.php
+++ b/src/RequestInfo.php
@@ -24,7 +24,6 @@ class RequestInfo implements \JsonSerializable {
 	const HEAD    = 'HEAD';
 	const OPTIONS = 'OPTIONS';
 	const TRACE   = 'TRACE';
-	const CONNECT = 'CONNECT';
 
 	/**
 	 * @var mixed

--- a/test/MockWebServer_IntegrationTest.php
+++ b/test/MockWebServer_IntegrationTest.php
@@ -89,6 +89,32 @@ class MockWebServer_IntegrationTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals("Past the end of the ResponseStack", $content);
 	}
 
+	public function testHttpMethods() {
+	    $methods = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS', 'TRACE'];
+
+	    foreach ($methods as $method)
+	    {
+            $url = self::$server->setResponseOfPath(
+                '/definedPath',
+                new Response(
+                    'This is our http body response',
+                    ['X-Foo-Bar' => 'Baz'],
+                    200
+                ),
+                $method
+            );
+
+            $context = stream_context_create(['http' => ['method'  => $method]]);
+            $content = file_get_contents($url, false, $context);
+
+            $this->assertContains('X-Foo-Bar: Baz', $http_response_header);
+
+            if ($method != 'HEAD') {
+                $this->assertEquals("This is our http body response", $content);
+            }
+        }
+    }
+
 	/**
 	 * Regression Test - Was a problem in 1.0.0-beta.2
 	 */

--- a/test/MockWebServer_IntegrationTest.php
+++ b/test/MockWebServer_IntegrationTest.php
@@ -3,6 +3,7 @@
 use donatj\MockWebServer\MockWebServer;
 use donatj\MockWebServer\Response;
 use donatj\MockWebServer\ResponseStack;
+use donatj\MockWebServer\RequestInfo;
 
 class MockWebServer_IntegrationTest extends PHPUnit_Framework_TestCase {
 
@@ -90,14 +91,23 @@ class MockWebServer_IntegrationTest extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testHttpMethods() {
-	    $methods = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS', 'TRACE'];
+	    $methods = [
+	        RequestInfo::GET,
+            RequestInfo::POST,
+            RequestInfo::PUT,
+            RequestInfo::PATCH,
+            RequestInfo::DELETE,
+            RequestInfo::HEAD,
+            RequestInfo::OPTIONS,
+            RequestInfo::TRACE
+        ];
 
 	    foreach ($methods as $method)
 	    {
             $url = self::$server->setResponseOfPath(
                 '/definedPath',
                 new Response(
-                    'This is our http body response',
+                    "This is our http $method body response",
                     ['X-Foo-Bar' => 'Baz'],
                     200
                 ),
@@ -109,8 +119,8 @@ class MockWebServer_IntegrationTest extends PHPUnit_Framework_TestCase {
 
             $this->assertContains('X-Foo-Bar: Baz', $http_response_header);
 
-            if ($method != 'HEAD') {
-                $this->assertEquals("This is our http body response", $content);
+            if ($method != RequestInfo::HEAD) {
+                $this->assertEquals("This is our http $method body response", $content);
             }
         }
     }


### PR DESCRIPTION
### Purpose

This PR adds support for multiple HTTP methods (and solves the existing issue #3). It does this by adding the HTTP method as the file extensions for the response "alias path". By default it now only supports `GET` requests.

### Example

```php
<?php
$server = new MockWebServer;
$server->start();

$url = $server->setResponseOfPath('/foo/bar', new Response("This is our http POST response"), RequestInfo::POST);

echo "Request to $url:\n";

$context = stream_context_create(['http' => ['method'  => 'POST']]);
$content = file_get_contents($url, false, $context);

echo $content;
```

I also added a new `methods.php` example in the `examples` directory.

### Tests 

A new test is added to `MockWebServer_IntegrationTest` called `testHttpMethods`.

### Misc

If there are any changes you'd like to see to this PR, just let me know. Thanks for an excellent tool!