### PR TITLE
Reduce sleep to make tests more fast

### DIFF
--- a/src/InternalServer.php
+++ b/src/InternalServer.php
@@ -38,10 +38,8 @@ class InternalServer {
 
 		$this->tmpPath = $tmpPath;
 
-		if ($request->getParsedUri()['path'] !== '/__health_check__') {
-			$count = self::incrementRequestCounter($this->tmpPath);
-			$this->logRequest($request, $count);
-		}
+		$count = self::incrementRequestCounter($this->tmpPath);
+		$this->logRequest($request, $count);
 
 		$this->header  = $header;
 		$this->request = $request;

--- a/src/InternalServer.php
+++ b/src/InternalServer.php
@@ -38,8 +38,10 @@ class InternalServer {
 
 		$this->tmpPath = $tmpPath;
 
-		$count = self::incrementRequestCounter($this->tmpPath);
-		$this->logRequest($request, $count);
+		if ($request->getParsedUri()['path'] !== '/__health_check__') {
+			$count = self::incrementRequestCounter($this->tmpPath);
+			$this->logRequest($request, $count);
+		}
 
 		$this->header  = $header;
 		$this->request = $request;

--- a/src/MockWebServer.php
+++ b/src/MockWebServer.php
@@ -86,7 +86,7 @@ class MockWebServer {
 			throw new Exceptions\ServerException("Error starting server, received '{$this->pid}', expected int PID");
 		}
 
-		for ($i=0; $i<=2;$i++) {
+		for ($i=0; $i<=2; $i++) {
 			if( $this->isRunning() ) {
 				break;
 			}

--- a/src/MockWebServer.php
+++ b/src/MockWebServer.php
@@ -86,12 +86,14 @@ class MockWebServer {
 			throw new Exceptions\ServerException("Error starting server, received '{$this->pid}', expected int PID");
 		}
 
-		for ($i=0; $i<=2; $i++) {
-			$output = @file_get_contents("http://{$this->host}:{$this->port}/__health_check__");
-			if( strpos($output, '{') === 0 ) {
+		for( $i = 0; $i <= 20; $i++ ) {
+			usleep(100000);
+
+			$open = @fsockopen($this->host, $this->port);
+			if( is_resource($open) ) {
+				fclose($open);
 				break;
 			}
-			usleep(500000); // just to make sure it's fully started up, maybe not necessary
 		}
 
 		if( !$this->isRunning() ) {

--- a/src/MockWebServer.php
+++ b/src/MockWebServer.php
@@ -86,7 +86,12 @@ class MockWebServer {
 			throw new Exceptions\ServerException("Error starting server, received '{$this->pid}', expected int PID");
 		}
 
-		sleep(1); // just to make sure it's fully started up, maybe not necessary
+		for ($i=0; $i<=2;$i++) {
+			if( $this->isRunning() ) {
+				break;
+			}
+			usleep(500000); // just to make sure it's fully started up, maybe not necessary
+		}
 
 		if( !$this->isRunning() ) {
 			throw new Exceptions\ServerException("Failed to start server. Is something already running on port {$this->port}?");

--- a/src/MockWebServer.php
+++ b/src/MockWebServer.php
@@ -87,7 +87,8 @@ class MockWebServer {
 		}
 
 		for ($i=0; $i<=2; $i++) {
-			if( $this->isRunning() ) {
+			$output = @file_get_contents("http://{$this->host}:{$this->port}/__health_check__");
+			if( strpos($output, '{') === 0 ) {
 				break;
 			}
 			usleep(500000); // just to make sure it's fully started up, maybe not necessary


### PR DESCRIPTION
I used microseconds to enable testing at shorter intervals.
On the first run there is no sleep.
In the second run, sleep is half a second.
Repetitions are made for 1 and a half seconds.