### PR TITLE
Add #[ReturnTypeWillChange] for PHP 8.1 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest]
-        php-versions: ['5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0']
+        php-versions: ['5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
 
     runs-on: ${{ matrix.operating-system }}
 
@@ -25,8 +25,13 @@ jobs:
         php-version: ${{ matrix.php-versions }}
         extensions: sockets, json, curl
 
-    - name: Install dependencies with composer
+    - name: Install dependencies with composer for PHP <= 8.0
+      if: matrix.php-versions <= '8.0'
       run: composer install
+
+    - name: Install dependencies with composer for PHP 8.1
+      if: matrix.php-versions == '8.1'
+      run: composer req phpspec/prophecy:dev-master@dev --dev
 
     - name: Test with phpunit
       run: vendor/bin/phpunit

--- a/src/RequestInfo.php
+++ b/src/RequestInfo.php
@@ -85,6 +85,7 @@ class RequestInfo implements \JsonSerializable {
 	 * which is a value of any type other than a resource.
 	 * @since 5.4.0
 	 */
+	#[\ReturnTypeWillChange]
 	public function jsonSerialize() {
 		return [
 			self::JSON_KEY_GET          => $this->get,


### PR DESCRIPTION
In PHP 8.1 the return type of JsonSerializable::jsonSerialize() was added.
To maintain compatibility with older PHP versions the attribute
#[ReturnTypeWillChange] was introduced.

Deprecation warning: Return type of donatj\MockWebServer\RequestInfo::jsonSerialize()
should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the
#[ReturnTypeWillChange] attribute should be used to temporarily suppress the notice

See also: https://wiki.php.net/rfc/internal_method_return_types