### PR TITLE
Update minimum PHP version to 7.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 on:
-  - pull_request
-  - push
+  push:
+    branches:
+      - "**"
+  pull_request:
+    branches:
+      - "master"
 
 name: CI
 
@@ -11,7 +15,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest, windows-latest]
-        php-versions: ['5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
+        php-versions: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
 
     runs-on: ${{ matrix.operating-system }}
 

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
 		}
 	],
 	"require": {
-		"php": ">=5.4",
+		"php": ">=7.1",
 		"ext-sockets": "*",
 		"ext-json": "*",
 		"ext-curl": "*",

--- a/test/InternalServerTest.php
+++ b/test/InternalServerTest.php
@@ -2,6 +2,7 @@
 
 use donatj\MockWebServer\InternalServer;
 use donatj\MockWebServer\MockWebServer;
+use donatj\MockWebServer\RequestInfo;
 use PHPUnit\Framework\TestCase;
 
 class InternalServerTest extends TestCase {
@@ -9,7 +10,7 @@ class InternalServerTest extends TestCase {
 	private $testTmpDir;
 	private $server;
 
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		$this->testTmpDir = __DIR__ . DIRECTORY_SEPARATOR . 'testTemp';
@@ -21,7 +22,7 @@ class InternalServerTest extends TestCase {
 		file_put_contents($counterFileName, '0');
 	}
 
-	public function tearDown() {
+	public function tearDown(): void {
 		parent::tearDown();
 		$this->removeTempDirectory();
 	}
@@ -70,7 +71,7 @@ class InternalServerTest extends TestCase {
 	}
 
 	public function testShouldLogRequestsOnInstanceCreate() {
-		$fakeReq = new \donatj\MockWebServer\RequestInfo([
+		$fakeReq = new RequestInfo([
 			'REQUEST_URI' => '',
 		],
 			[], [], [], [], [], '');


### PR DESCRIPTION
Wondering if this Windows PR might be ready for prime time?

I think with the wide range of PHP versions you are testing you need to include a `composer.lock` file for the oldest version. 

For PHPUnit the requirements changed so the new versions require the overridden methods to have the same signature (which means return types)
ala
```php
public function setUp(): void {
```
So this is required for PHP 7.1 but `void` is not valid before 7.1.

Seems like (IMHO) it might be time to drop support for extremely out-of-date versions.

Because otherwise this passes your tests.