### PR TITLE
Replaced STDIN constant with php://stdin

### DIFF
--- a/src/MockWebServer.php
+++ b/src/MockWebServer.php
@@ -292,7 +292,7 @@ class MockWebServer {
 		$cwd   = null;
 
 		$output = tmpfile();
-		$process = proc_open($fullCmd, [STDIN, $output, $output], $pipes, $cwd, $env, [
+		$process = proc_open($fullCmd, [fopen('php://stdin', 'r'), $output, $output], $pipes, $cwd, $env, [
 			'suppress_errors' => false,
 			'bypass_shell'    => true,
 		]);


### PR DESCRIPTION
The STDIN constant is defined by `cli` SAPI and it doesn't seem to be defined when running Drupal's functional tests:

![image](https://user-images.githubusercontent.com/771113/204215152-102d4c62-72e8-49b0-87cb-3e4dbc004354.png)

I didn't dig too deep to figure out why, but I think it has something to do how Drupal sets up the functional/browser test stack: 

https://www.drupal.org/docs/automated-testing/phpunit-in-drupal/phpunit-browser-test-tutorial#s-how-drupals-browser-tests-work

