### PR TITLE
Add DelayResponse support to ResponseStack

### DIFF
--- a/src/ResponseStack.php
+++ b/src/ResponseStack.php
@@ -7,7 +7,7 @@ namespace donatj\MockWebServer;
  *
  * When the stack is empty, the server will return a customizable response defaulting to a 404.
  */
-class ResponseStack implements MultiResponseInterface {
+class ResponseStack implements InitializingResponseInterface, MultiResponseInterface {
 
 	private $ref;
 
@@ -37,6 +37,12 @@ class ResponseStack implements MultiResponseInterface {
 
 		$this->currentResponse = reset($this->responses) ?: null;
 		$this->pastEndResponse = new Response('Past the end of the ResponseStack', [], 404);
+	}
+
+	public function initialize( RequestInfo $request ) : void {
+		if( $this->currentResponse instanceof InitializingResponseInterface ) {
+			$this->currentResponse->initialize($request);
+		}
 	}
 
 	public function next() : bool {

--- a/test/Integration/MockWebServer_IntegrationTest.php
+++ b/test/Integration/MockWebServer_IntegrationTest.php
@@ -221,6 +221,27 @@ class MockWebServer_IntegrationTest extends TestCase {
 		$this->assertGreaterThan(.9, microtime(true) - $start, 'Delayed response should take ~1 seconds longer than realtime response');
 	}
 
+	public function testMultiResponseWithPartialDelay() : void {
+		$multi = new ResponseStack(
+			new Response('Response One', [ 'X-Boop-Bat' => 'Sauce' ], 200),
+			new DelayedResponse(new Response('Response Two', [ 'X-Slaw-Dawg: FranCran' ], 200), 1000000)
+		);
+
+		$path = self::$server->setResponseOfPath('/delayedMultiPath', $multi);
+
+		$start      = microtime(true);
+		$contentOne = file_get_contents($path);
+		$this->assertSame($contentOne, 'Response One');
+		$this->assertContains('X-Boop-Bat: Sauce', $http_response_header);
+		$this->assertLessThan(.2, microtime(true) - $start, 'Delayed response should take less than 200ms');
+
+		$start      = microtime(true);
+		$contentTwo = file_get_contents($path);
+		$this->assertSame($contentTwo, 'Response Two');
+		$this->assertContains('X-Slaw-Dawg: FranCran', $http_response_header);
+		$this->assertGreaterThan(.9, microtime(true) - $start, 'Delayed response should take ~1 seconds longer than realtime response');
+	}
+
 	/**
 	 * Regression Test - Was a problem in 1.0.0-beta.2
 	 */


### PR DESCRIPTION
Hi!

I added the capability to honor the DelayedResponse when it is inside a ResponseStack. I'm was trying to test the retry behavior on my app, so I needed to emulate 1 response with high delay than the second one in other to only trigger the timeout in the first one.