### PR TITLE
Fix descriptor opening for bad stream wrappers

### DIFF
--- a/src/MockWebServer.php
+++ b/src/MockWebServer.php
@@ -30,9 +30,9 @@ class MockWebServer {
 	/**
 	 * Contains the descriptors for the process after it has been started
 	 *
-	 * @var array|null
+	 * @var resource[]
 	 */
-	private $descriptors = null;
+	private $descriptors = [];
 
 	/**
 	 * TestWebServer constructor.
@@ -131,12 +131,8 @@ class MockWebServer {
 			}
 		}
 
-		if( $this->descriptors ) {
-			foreach( $this->descriptors as $descriptor ) {
-				if( is_resource($descriptor) ) {
-					fclose($descriptor);
-				}
-			}
+		foreach( $this->descriptors as $descriptor ) {
+			@fclose($descriptor);
 		}
 	}
 

--- a/src/MockWebServer.php
+++ b/src/MockWebServer.php
@@ -285,9 +285,9 @@ class MockWebServer {
 	}
 
 	/**
-	 * @return array [resource, resource[]]
+	 * @return array{resource, resource[]}
 	 */
-	private function startServer( string $fullCmd ) {
+	private function startServer( string $fullCmd ) : array {
 		if( !$this->isWindowsPlatform() ) {
 			// We need to prefix exec to get the correct process http://php.net/manual/ru/function.proc-get-status.php#93382
 			$fullCmd = 'exec ' . $fullCmd;

--- a/src/MockWebServer.php
+++ b/src/MockWebServer.php
@@ -286,14 +286,13 @@ class MockWebServer {
 		$env   = null;
 		$cwd   = null;
 
-		$stdin   = fopen('php://stdin', 'rb');
 		$stdoutf = tempnam(sys_get_temp_dir(), 'MockWebServer.stdout');
 		$stderrf = tempnam(sys_get_temp_dir(), 'MockWebServer.stderr');
 
 		$descriptorSpec = [
-			0 => $stdin,
-			1 => [ 'file', $stdoutf, 'a' ],
-			2 => [ 'file', $stderrf, 'a' ],
+			0 => fopen('php://stdin', 'rb'),
+			1 => fopen($stdoutf, 'a'),
+			2 => fopen($stderrf, 'a'),
 		];
 
 		$process = proc_open($fullCmd, $descriptorSpec, $pipes, $cwd, $env, [


### PR DESCRIPTION
It seems 'files' stream wrappers might not be able to handle the 'file' array syntax.

