### PR TITLE
Do not crash with binary response body

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -24,7 +24,7 @@ class Response implements ResponseInterface {
 
 	public function getRef() : string {
 		$content = json_encode([
-			$this->body,
+			md5($this->body),
 			$this->status,
 			$this->headers,
 		]);

--- a/test/Integration/MockWebServer_IntegrationTest.php
+++ b/test/Integration/MockWebServer_IntegrationTest.php
@@ -251,6 +251,21 @@ class MockWebServer_IntegrationTest extends TestCase {
 		$this->assertSame('', file_get_contents($url));
 	}
 
+	public function testBinaryResponse() : void {
+		$response = new Response(
+			gzencode('This is our http body response'),
+			[ 'Content-Encoding: gzip' ],
+			200
+		);
+
+		$url = self::$server->setResponseOfPath('/', $response);
+		$content = @file_get_contents($url);
+
+		$this->assertNotFalse($content);
+		$this->assertSame('This is our http body response', gzdecode($content));
+		$this->assertContains('Content-Encoding: gzip', $http_response_header);
+	}
+
 	/**
 	 * @dataProvider requestInfoProvider
 	 */


### PR DESCRIPTION
This is needed to simulate e.g. gzip response without having to override the `getRef` method.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Modify `getRef()` in `Response.php` to handle binary response bodies and add a test for gzip-encoded responses.
> 
>   - **Behavior**:
>     - Modify `getRef()` in `Response.php` to use `md5($this->body)` instead of `$this->body` to prevent JSON encoding errors with binary data.
>     - Add test `testBinaryResponse()` in `MockWebServer_IntegrationTest.php` to verify handling of gzip-encoded binary response bodies.
>   - **Tests**:
>     - `testBinaryResponse()` checks that a gzip-encoded response is correctly decoded and that the `Content-Encoding: gzip` header is present.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=donatj%2Fmock-webserver&utm_source=github&utm_medium=referral)<sup> for afaced587590c78a7c517604a20aab451202c694. You can [customize](https://app.ellipsis.dev/donatj/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->