### PR TITLE
Add PHP 8.5 to CI workflow PHP versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest, windows-latest]
-        php-versions: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
+        php-versions: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
 
     runs-on: ${{ matrix.operating-system }}
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add PHP 8.5 to CI workflow in `.github/workflows/ci.yml` for testing.
> 
>   - **CI Workflow**:
>     - Add PHP 8.5 to `php-versions` matrix in `.github/workflows/ci.yml` for CI testing.
>     - Ensures tests run on PHP 8.5 alongside existing versions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=donatj%2Fmock-webserver&utm_source=github&utm_medium=referral)<sup> for dd8c33f2f37b7ec9fb6b6254d88e4fe3e71a537c. You can [customize](https://app.ellipsis.dev/donatj/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->