### PR TITLE
Use PHP_BINARY for server command execution

### DIFF
--- a/src/MockWebServer.php
+++ b/src/MockWebServer.php
@@ -63,7 +63,7 @@ class MockWebServer {
 		$script = __DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'server' . DIRECTORY_SEPARATOR . 'server.php';
 
 		$stdout = tempnam(sys_get_temp_dir(), 'mockserv-stdout-');
-		$cmd    = sprintf("php -S %s:%d %s", $this->host, $this->port, escapeshellarg($script));
+		$cmd    = sprintf("%s -S %s:%d %s", PHP_BINARY, $this->host, $this->port, escapeshellarg($script));
 
 		if( !putenv(self::TMP_ENV . '=' . $this->tmpDir) ) {
 			throw new Exceptions\RuntimeException('Unable to put environmental variable');

--- a/src/MockWebServer.php
+++ b/src/MockWebServer.php
@@ -63,7 +63,12 @@ class MockWebServer {
 		$script = __DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'server' . DIRECTORY_SEPARATOR . 'server.php';
 
 		$stdout = tempnam(sys_get_temp_dir(), 'mockserv-stdout-');
-		$cmd    = sprintf("%s -S %s:%d %s", PHP_BINARY, $this->host, $this->port, escapeshellarg($script));
+		$cmd    = sprintf("%s -S %s:%d %s",
+			escapeshellarg(PHP_BINARY),
+			escapeshellarg($this->host),
+			$this->port,
+			escapeshellarg($script)
+		);
 
 		if( !putenv(self::TMP_ENV . '=' . $this->tmpDir) ) {
 			throw new Exceptions\RuntimeException('Unable to put environmental variable');
@@ -71,7 +76,7 @@ class MockWebServer {
 
 		$fullCmd = sprintf('%s > %s 2>&1',
 			$cmd,
-			$stdout
+			escapeshellarg($stdout)
 		);
 
 		InternalServer::incrementRequestCounter($this->tmpDir, 0);


### PR DESCRIPTION
Currently, we're dependent on PHP being in the $PATH of the user running the tests. 

This usually works, but something happened with macOS 26.3 and that seems to not always be the case in certain contexts such as running tests from PHPStorm and within other _Applications_ not running the tests from within a shell context.

We do not need to depend on PATH for the php executable and can instead get the binary running the tests to begin with, `PHP_BINARY`

This also prevents a weird edge case where the PHP version running the test might not be the same version running the server.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Use `PHP_BINARY` in `MockWebServer.php` to ensure consistent PHP version for server execution.
> 
>   - **Behavior**:
>     - Modify `start()` in `MockWebServer.php` to use `PHP_BINARY` for server command execution instead of `php` in the system's PATH.
>     - Ensures the PHP version running the tests matches the server's PHP version, preventing version mismatch issues.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=donatj%2Fmock-webserver&utm_source=github&utm_medium=referral)<sup> for 9ac348c8ee8fbb247a4131d0dc7d3802f3e86462. You can [customize](https://app.ellipsis.dev/donatj/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->