### PR TITLE
Upgrade PHPUnit, increase minimum PHP to 7.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest, windows-latest]
-        php-versions: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
+        php-versions: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
 
     runs-on: ${{ matrix.operating-system }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,5 +34,5 @@ jobs:
     - name: Install PHPStan if PHP >= 7.4
       if: startsWith(matrix.php-versions, '7.4') || startsWith(matrix.php-versions, '8.')
       run: |
-       composer require --dev phpstan/phpstan:2.1.17
+       composer require --dev phpstan/phpstan:2.1.39
        vendor/bin/phpstan

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Mock Web Server creates a local Web Server you can make predefined requests agai
 
 ## Requirements
 
-- **php**: >=7.1
+- **php**: >=7.2
 - **ext-sockets**: *
 - **ext-json**: *
 - **ralouphie/getallheaders**: ~2.0 || ~3.0
@@ -121,7 +121,7 @@ Outputs:
 ```
 Requesting: http://127.0.0.1:61874/definedPath
 
-HTTP/1.0 200 OK
+HTTP/1.1 200 OK
 Host: 127.0.0.1:61874
 Date: Tue, 31 Aug 2021 19:50:15 GMT
 Connection: close
@@ -168,7 +168,7 @@ echo $content . "\n";
 Outputs:
 
 ```
-HTTP/1.0 404 Not Found
+HTTP/1.1 404 Not Found
 Host: 127.0.0.1:61874
 Date: Tue, 31 Aug 2021 19:50:15 GMT
 Connection: close

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
 		}
 	],
 	"require": {
-		"php": ">=7.1",
+		"php": ">=7.2",
 		"ext-sockets": "*",
 		"ext-json": "*",
 		"ralouphie/getallheaders": "~2.0 || ~3.0"
@@ -32,7 +32,7 @@
 	},
 	"require-dev": {
 		"donatj/drop": "^1.0",
-		"phpunit/phpunit": "~7|~9",
+		"phpunit/phpunit": "~8|~9",
 		"friendsofphp/php-cs-fixer": "^3.1",
 		"squizlabs/php_codesniffer": "^3.6",
 		"corpus/coding-standard": "^0.6.0 || ^0.9.0",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,7 +3,7 @@ parameters:
 	paths:
 		- src
 		- server
-	phpVersion: 70100
+	phpVersion: 70200
 	ignoreErrors:
 		- 
 			identifier: missingType.iterableValue


### PR DESCRIPTION
Updated PHP version requirement and PHPUnit version in composer.json.

PHPUnit had a vulnerability marked as affecting every single existing version. They then only patched back to version 8.x. 

PHPUnit 8.x only supports PHP 7.2 or newer, so we can no longer support PHP 7.1
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Upgrade minimum PHP version to 7.2 and PHPUnit to version 8.x due to security vulnerability, updating `composer.json`, `README.md`, and CI configuration.
> 
>   - **PHP Version**:
>     - Increase minimum PHP version to 7.2 in `composer.json` and `README.md`.
>   - **PHPUnit Version**:
>     - Update PHPUnit version to `~8|~9` in `composer.json` due to vulnerability.
>   - **CI Configuration**:
>     - Remove PHP 7.1 from `php-versions` matrix in `.github/workflows/ci.yml`.
>   - **Misc**:
>     - Change HTTP version in example outputs in `README.md` from `HTTP/1.0` to `HTTP/1.1`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=donatj%2Fmock-webserver&utm_source=github&utm_medium=referral)<sup> for b02ec2dc19a3d22087da8c3afaf23d00edca1c83. You can [customize](https://app.ellipsis.dev/donatj/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->